### PR TITLE
compile fixes for recent OS X/Xcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ endif
 WARN = -Wall -Wno-unused-function -finline-functions -Wno-sign-compare #-Wconversion
 INCPATH = -I./src -I$(THIRD_PATH)/include
 CFLAGS = -std=c++0x $(WARN) $(OPT) $(INCPATH)
-LDFLAGS += $(THIRD_LIB) -lpthread -lrt
+LDFLAGS += $(THIRD_LIB) -lpthread
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+	LFLAGS += -lrt
+endif
 
 PS_LIB = build/libps.a
 PS_MAIN = build/libpsmain.a

--- a/src/system/dashboard.cc
+++ b/src/system/dashboard.cc
@@ -3,7 +3,7 @@
 
 namespace PS {
 
-bool NodeIDCmp::operator()(const NodeID& a, const NodeID& b) {
+bool NodeIDCmp::operator()(const NodeID& a, const NodeID& b) const {
   string a_primary, a_secondary;
   splitNodeID(a, a_primary, a_secondary);
   string b_primary, b_secondary;
@@ -17,7 +17,7 @@ bool NodeIDCmp::operator()(const NodeID& a, const NodeID& b) {
   }
 }
 
-void NodeIDCmp::splitNodeID(const NodeID& in, string& primary, string& secondary) {
+void NodeIDCmp::splitNodeID(const NodeID& in, string& primary, string& secondary) const {
   size_t tailing_alpha_idx = in.find_last_not_of("0123456789");
   if (std::string::npos == tailing_alpha_idx) {
     primary = in;

--- a/src/system/dashboard.h
+++ b/src/system/dashboard.h
@@ -5,8 +5,8 @@
 namespace PS {
 
 struct NodeIDCmp {
-  void splitNodeID(const NodeID& in, string& primary, string& secondary);
-  bool operator()(const NodeID& a, const NodeID& b);
+  void splitNodeID(const NodeID& in, string& primary, string& secondary) const;
+  bool operator()(const NodeID& a, const NodeID& b) const;
 };
 
 class Dashboard {


### PR DESCRIPTION
When I compiled ps on OS X Yosemite 10.10.2, Xcode 6.2, I got something like:

/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/map:1192:17: error: no matching
      function for call to object of type 'const PS::NodeIDCmp'
            if (__tree_.value_comp().key_comp()(__k, __nd->__value_.__cc.first))
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
... ...
src/system/dashboard.cc:8:3: error: member function 'splitNodeID' not viable: 'this' argument has type 'const PS::NodeIDCmp', but function is not marked const
  splitNodeID(a, a_primary, a_secondary);
  ^~~~~~~~~~~

Also, there's no librt on OS X
